### PR TITLE
ClusterRole and ClusterRoleBindings made namespace-specific

### DIFF
--- a/chart/templates/rolebinding.yaml
+++ b/chart/templates/rolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "manticoresearch.fullname" . }}
+  name: {{ include "manticoresearch.fullname" . }}-{{ .Release.Namespace }}
 rules:
   - apiGroups: [ '' ]
     resources: [ 'nodes', 'configmaps', 'pods', 'services' ]
@@ -24,11 +24,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "manticoresearch.fullname" . }}
+  name: {{ include "manticoresearch.fullname" . }}-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "manticoresearch.fullname" . }}
+  name: {{ include "manticoresearch.fullname" . }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This is to remove the naming collision for multi-namespace releases.
This is likely a temporary solution. Likely the relese doesn't really
need a cluster role, or if it really does, then it may need to be
converted to operator.

https://github.com/manticoresoftware/manticoresearch-helm/issues/12