### PR TITLE
fix: Improve cluster domain name handling

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -350,6 +350,7 @@ For more details, refer to the [Kubernetes documentation](https://kubernetes.io/
 | serviceMonitor.enabled               | Enables service monitor resource for exporting runtime metrics to Prometheus                        | false                                                                                              |
 | serviceMonitor.interval              | Set how frequently Prometheus should scrape                        | 30s                                                                                                |
 | serviceMonitor.scrapeTimeout         | Set timeout for scrape                        | 10s                                                                                                |
+| global.clusterDomainSuffix           | DNS suffix for cluster, to allow for configuration stripping of cluster suffix                      | cluster.local                                                                                      |
 
 </details>
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Manticore Search Helm Chart
 
-**Version:** 9.2.14
+**Version:** 9.2.14-20250422
 
 The Manticore Search Helm Chart is designed to deploy and manage Manticore Search in Kubernetes. It ensures high availability with out-of-the-box replication and improves read throughput through automatic load balancing.
 

--- a/charts/manticoresearch/CHANGELOG.md
+++ b/charts/manticoresearch/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 9.2.14-20250422
+
+* Add global value for DNS suffix
+  * This allows for modifying the behaviour of the configuration script, which
+    removes cluster DNS suffix from Manticoresearch node addresses
+  * Specifically, setting global.clusterDomainSuffix in values.yaml allows you to
+    override the default (svc.cluster.local) to specify the suffix to strip away
+
 ### 9.2.14
 
 * 🚀 Release Manticore Search 9.2.14

--- a/charts/manticoresearch/Chart.yaml
+++ b/charts/manticoresearch/Chart.yaml
@@ -20,4 +20,4 @@ version: 9.2.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 9.2.14
+appVersion: 9.2.15

--- a/charts/manticoresearch/Chart.yaml
+++ b/charts/manticoresearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 9.2.14
+version: 9.2.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/manticoresearch/Chart.yaml
+++ b/charts/manticoresearch/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 9.2.15
+version: 9.2.14-20250422
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 9.2.15
+appVersion: 9.2.14

--- a/charts/manticoresearch/templates/manticore-worker.yaml
+++ b/charts/manticoresearch/templates/manticore-worker.yaml
@@ -67,6 +67,8 @@ spec:
             value: {{ .Values.worker.service.binary.port | quote }}
           - name: CLUSTER_NAME
             value: {{ .Values.worker.clusterName }}
+          - name: CLUSTER_DOMAIN_SUFFIX
+            value: {{ .Values.global.clusterDomainSuffix }}
           - name: REPLICATION_MODE
             value: {{ .Values.worker.replicationMode }}
           - name: LOG_LEVEL

--- a/charts/manticoresearch/values.yaml
+++ b/charts/manticoresearch/values.yaml
@@ -8,6 +8,7 @@ global:
 #     - myRegistryKeySecretName
 #   storageClass: myStorageClass
   manticoresearch: {}
+  clusterDomainSuffix: cluster.local
 
 balancer:
   enabled: true

--- a/sources/manticore-worker/manticore.conf
+++ b/sources/manticore-worker/manticore.conf
@@ -1,4 +1,6 @@
-#!/bin/sh
-sed 's/$hostname/'$(hostname -f)'/' $CONFIGMAP_PATH | \
-sed 's/\.svc\.[.a-zA-Z0-9-]\+//' | \
-sed 's/$server_id/'$(echo $HOSTNAME | sed 's/.*-//')'/'
+#!/bin/bash
+CLUSTER_DOMAIN_SUFFIX=${CLUSTER_DOMAIN_SUFFIX:=cluster.local}
+
+sed 's/$hostname/'$(hostname -f)'/' $CONFIGMAP_PATH |
+  sed "s/\.svc\.${CLUSTER_DOMAIN_SUFFIX}//" |
+  sed 's/$server_id/'$(echo $HOSTNAME | sed 's/.*-//')'/'


### PR DESCRIPTION
This fixes a shortcoming in the manticore.conf wrapper for updating local configuration: it doesn't take possible deviations from standard kubernetes cluster DNS into consideration.

Kubernetes doesn't enforce svc.cluster.local and in fact you can have different DNS in place there. For anything that differs from svc.cluster.local, this script fails and thus blocks clustering.

As an example, we have a cluster with DNS name of ds.bx.internal - with this name a fully qualified svc would be:

```
x.y.svc.ds.bx.internal
```

The manticore.conf script does not handle this and thus the configuration ends up wrong, and clustering doesn't happen.

The PR handles this by replacing like before (i.e. svc.) but without specifying the default naming. Tested in Kubernetes deployment with non-standard DNS and solves the problem.