### PR TITLE
feat: support persistent balancer agents

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -188,6 +188,30 @@ The balancer in Manticore Search is an optional component for managing high avai
 #### Configuration Options:
 - **Custom Behavior:** You can customize the balancer’s behavior using its HA strategy (`table_ha_strategy`).
 - **Enhanced Performance:** Scaling the number of balancer replicas improves the cluster’s ability to handle read requests.
+- **Persistent Remote Agents:** Set `balancer.config.agent.conn` to `pconn` to generate remote agents with `[conn=pconn]`. To make persistent connections effective, also set `persistent_connections_limit` to a value greater than `0` in `balancer.config.content`.
+
+Example:
+
+```yaml
+balancer:
+  config:
+    agent:
+      conn: pconn
+    content: |
+      searchd
+      {
+        listen = /var/run/mysqld/mysqld.sock:mysql
+        listen = 9306:mysql
+        listen = 9308:http
+        listen = 9312
+        persistent_connections_limit = 128
+        query_log = /dev/stdout
+        query_log_format = sphinxql
+        pid_file = /var/run/manticore/searchd.pid
+        binlog_path = /var/lib/manticore
+        shutdown_timeout = 25s
+      }
+```
 
 
   For more details, refer to the [Load Balancing documentation](https://manual.manticoresearch.com/dev/Creating_a_cluster/Remote_nodes/Load_balancing#Load-balancing).
@@ -375,6 +399,7 @@ worker:
 | balancer.enabled | Enable/disable the load balancer | true |
 | balancer.replicaCount | Default balancers count (number of replicas)                                                                              | 1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | balancer.runInterval | How often to check for schema changes on workers, seconds                                                                 | 5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| balancer.config.agent.conn | Remote agent connection mode. Set to `pconn` to generate agents with `[conn=pconn]`. Requires `persistent_connections_limit > 0` in `balancer.config.content` to enable persistent connections. | "" |
 | balancer.config.content | Balancer config (only section `searchd`)                                                                                  | searchd<br>      {<br>       listen = /var/run/mysqld/mysqld.sock:mysql<br>        listen = 9306:mysql<br>        listen = 9308:http<br>        log = /dev/stdout<br>        query_log = /dev/stdout<br>        query_log_format = sphinxql<br>        pid_file = /var/run/manticore/searchd.pid<br>        binlog_path = /var/lib/manticore/data<br>      }                                                                                                                                                                                                                        |
 | worker.replicaCount | Default workers count (number of replicas)                                                                                | 3                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | worker.replicationMode | Workers replication mode                                                                                                  | master-slave                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |

--- a/charts/manticoresearch/templates/manticore-balancer.yaml
+++ b/charts/manticoresearch/templates/manticore-balancer.yaml
@@ -63,6 +63,12 @@ spec:
             value: {{ .Values.balancer.config.path | quote }}
           - name: TABLE_HA_STRATEGY
             value: {{ .Values.balancer.config.table_ha_strategy | quote }}
+          {{- $agentConn := lower (toString (default "" .Values.balancer.config.agent.conn)) }}
+          {{- if not (or (eq $agentConn "") (eq $agentConn "pconn")) }}
+            {{- fail "balancer.config.agent.conn must be empty or pconn" }}
+          {{- end }}
+          - name: AGENT_CONNECTION
+            value: {{ $agentConn | quote }}
           - name: BALANCER_PORT
             value: {{ .Values.balancer.service.ql.port | quote }}
           - name: WORKER_PORT

--- a/charts/manticoresearch/values.yaml
+++ b/charts/manticoresearch/values.yaml
@@ -35,6 +35,10 @@ balancer:
   config:
     path: /mnt/configmap.conf
     table_ha_strategy: nodeads
+    agent:
+      # Set to pconn to generate persistent remote agents.
+      # Requires persistent_connections_limit > 0 in balancer.config.content.
+      conn: ""
     content: |
       searchd
       {

--- a/clt_tests/tests/2-balancer-agent-pconn.rec
+++ b/clt_tests/tests/2-balancer-agent-pconn.rec
@@ -1,0 +1,56 @@
+––– block: ./init/init –––
+––– block: ./init/cleanup-release –––
+––– input –––
+printf 'balancer:\n  config:\n    agent:\n      conn: pconn\n    content: |\n      searchd\n      {\n        listen = /var/run/mysqld/mysqld.sock:mysql\n        listen = 9306:mysql\n        listen = 9308:http\n        listen = 9312\n        persistent_connections_limit = 128\n        query_log = /dev/stdout\n        query_log_format = sphinxql\n        pid_file = /var/run/manticore/searchd.pid\n        binlog_path = /var/lib/manticore\n        shutdown_timeout = 25s\n      }\n  image:\n    tag: 0.0.0-unstable\nworker:\n  image:\n    tag: 0.0.0-unstable\n' >/tmp/clt-values.yaml; cat /tmp/clt-values.yaml
+––– output –––
+balancer:
+  config:
+    agent:
+      conn: pconn
+    content: |
+      searchd
+      {
+        listen = /var/run/mysqld/mysqld.sock:mysql
+        listen = 9306:mysql
+        listen = 9308:http
+        listen = 9312
+        persistent_connections_limit = 128
+        query_log = /dev/stdout
+        query_log_format = sphinxql
+        pid_file = /var/run/manticore/searchd.pid
+        binlog_path = /var/lib/manticore
+        shutdown_timeout = 25s
+      }
+  image:
+    tag: 0.0.0-unstable
+worker:
+  image:
+    tag: 0.0.0-unstable
+––– block: ./init/install –––
+––– input –––
+if timeout 180 bash -c 'while [[ ! $(kubectl get po 2>&1 | grep "Running" | wc -l) -eq 4 ]]; do sleep 1; done'; then echo "OK"; else echo "Failed waiting until pods was deployed"; kubectl get po -o wide || true; for pod in $(kubectl get po --no-headers 2>/dev/null | awk '$3 != "Running" {print $1}'); do kubectl describe pod "$pod" || true; done; false; fi
+––– output –––
+OK
+––– input –––
+kubectl exec my-helm-manticoresearch-worker-0 -- mysql -h0 -P9306 -e "CREATE TABLE idx(title text)"; echo $?
+––– output –––
+0
+––– input –––
+kubectl exec my-helm-manticoresearch-worker-0 -- mysql -h0 -P9306 -e "ALTER CLUSTER manticore_cluster ADD idx"; echo $?
+––– output –––
+0
+––– input –––
+export BALANCER_NAME=$(kubectl get pods -l "app.kubernetes.io/name=manticoresearch,app.kubernetes.io/instance=my-helm,name=my-helm-manticoresearch-balancer" -o jsonpath="{.items[0].metadata.name}") && echo "Ok"
+––– output –––
+Ok
+––– input –––
+timeout 180 bash -c 'until kubectl exec "$BALANCER_NAME" -- sh -c "grep -q \"agent = .*:idx\\[conn=pconn\\]\" /etc/manticoresearch/manticore.conf" >/dev/null 2>&1; do sleep 2; done; kubectl exec "$BALANCER_NAME" -- sh -c "grep \"agent =\" /etc/manticoresearch/manticore.conf"'
+––– output –––
+	agent = #!/.+:idx\[conn=pconn\]/!#
+––– input –––
+kubectl exec $BALANCER_NAME -- mysql -h0 -P9306 -e "SHOW TABLES\G"
+––– output –––
+*************************** 1. row ***************************
+Table: idx
+#!/\s*Type: distributed/!#
+––– block: ./init/cleanup-release –––

--- a/sources/manticore-balancer/observer.php
+++ b/sources/manticore-balancer/observer.php
@@ -19,6 +19,7 @@ $instance        = null;
 $configMapPath   = null;
 $workerService   = null;
 $tableHAStrategy = null;
+$agentConnection = null;
 
 $variables = [
 	'workerPort'      => [ 'env' => 'WORKER_PORT', 'type' => 'int' ],
@@ -28,6 +29,7 @@ $variables = [
 	'configMapPath'   => [ 'env' => 'CONFIGMAP_PATH', 'type' => 'string' ],
 	'workerService'   => [ 'env' => 'WORKER_SERVICE', 'type' => 'string' ],
 	'tableHAStrategy' => [ 'env' => 'TABLE_HA_STRATEGY', 'type' => 'string' ],
+	'agentConnection' => [ 'env' => 'AGENT_CONNECTION', 'type' => 'string' ],
 ];
 
 foreach ( $variables as $variable => $desc ) {
@@ -47,6 +49,12 @@ foreach ( $variables as $variable => $desc ) {
 
 if (!in_array($tableHAStrategy, ['random', 'nodeads','noerrors','roundrobin'])){
 	Logger::info( "TABLE_HA_STRATEGY can be only {random|nodeads|noerrors|roundrobin}\n" );
+	exit( 1 );
+}
+
+$agentConnection = strtolower(trim($agentConnection));
+if (!in_array($agentConnection, ['', 'pconn'], true)){
+	Logger::info( "AGENT_CONNECTION can be empty or pconn\n" );
 	exit( 1 );
 }
 
@@ -82,11 +90,11 @@ $podsIps   = $resources->getPodIpAllConditions();
 
 if ( $tables !== [] ) {
 	$previousHash = $cache->get( Cache::TABLE_HASH );
-	$hash         = sha1( implode( '.', $tables ) . implode( $podsIps ) );
+	$hash         = sha1( implode( '.', $tables ) . implode( $podsIps ) . $agentConnection );
 
 	if ( $previousHash !== $hash ) {
 		Logger::info( "Starting config recompiling" );
-		saveConfig( $tables, $podsIps, $balancerPort, $configMapPath, $tableHAStrategy );
+		saveConfig( $tables, $podsIps, $balancerPort, $configMapPath, $tableHAStrategy, $agentConnection );
 		$cache->store( Cache::TABLE_HASH, $hash );
 	}
 } else {
@@ -95,7 +103,23 @@ if ( $tables !== [] ) {
 }
 
 
-function saveConfig( $tables, $nodes, $port, $configMapPath, $tableHAStrategy ) {
+function buildDistributedTableAgentValue( $table, $nodes, $agentConnection ) {
+	$agent = implode( "|", $nodes );
+	$options = [];
+
+	if ( $agentConnection === 'pconn' ) {
+		$options[] = 'conn=pconn';
+	}
+
+	if ( $options !== [] ) {
+		$agent .= ":" . $table . "[" . implode( ",", $options ) . "]";
+	}
+
+	return $agent;
+}
+
+
+function saveConfig( $tables, $nodes, $port, $configMapPath, $tableHAStrategy, $agentConnection ) {
 	$searchdConfig = file_get_contents( $configMapPath );
 	$prependConfig = '';
 	foreach ( $tables as $table ) {
@@ -103,7 +127,7 @@ function saveConfig( $tables, $nodes, $port, $configMapPath, $tableHAStrategy ) 
 		                  "{\n" .
 		                  "\ttype = distributed\n" .
 		                  "\tha_strategy = " . $tableHAStrategy . "\n" .
-		                  "\tagent = " . implode( "|", $nodes ) . "\n" .
+		                  "\tagent = " . buildDistributedTableAgentValue( $table, $nodes, $agentConnection ) . "\n" .
 		                  "}\n\n";
 	}
 


### PR DESCRIPTION
## What changed

This adds an optional balancer setting for generated distributed table agents:

```yaml
balancer:
  config:
    agent:
      conn: pconn
```

When enabled, the balancer observer writes remote table agents as:

```ini
agent = node1|node2|node3:table[conn=pconn]
```

The default remains unchanged. With the default empty value, generated agents keep the existing format:

```ini
agent = node1|node2|node3:table
```

The chart validates `balancer.config.agent.conn` and accepts only an empty value or `pconn`, so the generated config remains constrained to the supported persistent-connection mode.

## Why

In high-QPS deployments, the balancer-to-worker path can otherwise hit frequent remote-agent connection timeouts when the generated distributed-table agents use the default connection mode. Allowing the chart to generate `agent = ...[conn=pconn]` lets operators opt into persistent remote table connections for the balancer while keeping the existing default behavior unchanged.

## Notes

`conn=pconn` requires `persistent_connections_limit > 0` in the balancer `searchd` config. The README and CLT scenario include that setting in the example values.

## Validation

- `php -l sources/manticore-balancer/observer.php`
- `helm lint ./charts/manticoresearch`
- `helm template test ./charts/manticoresearch`
- `helm template test ./charts/manticoresearch --set-string balancer.config.agent.conn=pconn`
- `helm template test ./charts/manticoresearch --set-string balancer.config.agent.conn=PCONN`
- `helm template test ./charts/manticoresearch --set balancer.enabled=false`
- invalid value check: `helm template ... --set-string balancer.config.agent.conn=foo` fails with `balancer.config.agent.conn must be empty or pconn`
- `git diff --check`
- `clt_tests/run-local.sh --init --build-images --all --debug`

The full local CLT run passed the new `2-balancer-agent-pconn` scenario and the other chart scenarios, including the SST scale/replication scenario. On this local Apple Silicon Docker run, the pre-existing `2-searchd-extra-args` scenario failed on its `ps ... --logdebug` assertion even though its follow-up debug-log assertion passed. This PR does not touch the worker extra-args path or that scenario.