### PR TITLE
Build balancer config from ready workers

### DIFF
--- a/sources/manticore-balancer/observer.php
+++ b/sources/manticore-balancer/observer.php
@@ -74,23 +74,28 @@ $locker->checkLock();
 $resources = new Resources( new ApiClient(), $labels, new NotificationStub() );
 
 if ( $resources->getActivePodsCount() === 0 ) {
-	Logger::info( "No workers found" );
+	Logger::info( "No ready workers found" );
 	$locker->unlock();
 }
 $oldestWorker = $resources->getOldestActivePodName();
 
 if ( empty( $oldestWorker ) ) {
-	throw new RuntimeException( "Can't find oldest worker" );
+	throw new RuntimeException( "Can't find oldest ready worker" );
 }
 
 $manticore = new ManticoreConnector( $oldestWorker . '.' . $workerService, $workerPort, null, - 1 );
 $tables    = $manticore->getTables( false );
-$podsIps   = $resources->getPodIpAllConditions();
+$podsIps   = $resources->getPodsIp();
+
+// Kubernetes API item order is not stable, so normalize before hashing and rendering.
+sort( $tables );
+ksort( $podsIps, SORT_NATURAL );
+$podsIps = array_values( $podsIps );
 
 
 if ( $tables !== [] ) {
 	$previousHash = $cache->get( Cache::TABLE_HASH );
-	$hash         = sha1( implode( '.', $tables ) . implode( $podsIps ) . $agentConnection );
+	$hash         = sha1( implode( '.', $tables ) . implode( '.', $podsIps ) . $agentConnection );
 
 	if ( $previousHash !== $hash ) {
 		Logger::info( "Starting config recompiling" );


### PR DESCRIPTION
## Summary

- build balancer distributed table config from Kubernetes Ready worker pods only
- use the existing `Core\K8s\Resources` pod filtering instead of `getPodIpAllConditions()`
- sort table names and pod-name keyed worker IPs before hashing/rendering to keep generated config stable

## Why

The balancer observer currently uses `getPodIpAllConditions()`, which can include worker pod IPs before those pods are Ready. During worker changes this may add a joining or initializing worker to distributed table agents before it is ready to serve reads.

This update keeps the observer on the existing `Resources` abstraction and switches the balancer agent list to `getPodsIp()`, so it is based on the same Ready-filtered pod list used elsewhere in the auto-replication package.

The sorting is only for deterministic config generation: Kubernetes API item order is not contractual, so normalizing tables and pod-name keyed IPs avoids unnecessary hash changes and reloads when the underlying set is unchanged.

## Scope update after review

The previous `server_id` change was removed from this PR. This PR now focuses only on Ready worker selection for the balancer config and deterministic config hashing/rendering.

## Checks

- `git diff --check`
